### PR TITLE
Switch to anyhow instead of failure for error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ authors = ["Mark Mansi <markm@cs.wisc.edu>", "Bijan Tabatabai <btabatabai@wisc.e
 [dependencies]
 spurs = "0.9.0"
 spurs-util = "0.3.0"
-failure = "0.1.5"
-failure_derive = "0.1.5"
+anyhow = "1.0"
 chrono = "0.4.6"
 serde = { version = "1.0.87", features = [ "derive" ] }
 serde_json = "1.0.38"

--- a/src/background.rs
+++ b/src/background.rs
@@ -45,7 +45,7 @@ impl<'s> BackgroundContext<'s> {
     }
 
     /// Run the given `BackgroundRun` in the background on the remote.
-    pub fn spawn(&mut self, task: BackgroundTask<'s>) -> Result<(), failure::Error> {
+    pub fn spawn(&mut self, task: BackgroundTask<'s>) -> Result<(), anyhow::Error> {
         self.running.push(task);
         let handles = self.running.last().as_ref().unwrap().start(self.shell)?;
         self.handles.push(handles);
@@ -53,7 +53,7 @@ impl<'s> BackgroundContext<'s> {
         Ok(())
     }
 
-    pub fn notify_and_join_all(mut self) -> Result<(), failure::Error> {
+    pub fn notify_and_join_all(mut self) -> Result<(), anyhow::Error> {
         for j in self.running.iter() {
             j.notify(self.shell)?;
         }
@@ -67,7 +67,7 @@ impl<'s> BackgroundContext<'s> {
 }
 
 impl BackgroundTask<'_> {
-    fn start(&self, shell: &SshShell) -> Result<SshSpawnHandle, failure::Error> {
+    fn start(&self, shell: &SshShell) -> Result<SshSpawnHandle, anyhow::Error> {
         let stop_file_path = format!("/tmp/exp-{}-stop", self.name.replace(" ", "-"));
 
         // Note: command needs to _not_ end with a `;`
@@ -97,7 +97,7 @@ impl BackgroundTask<'_> {
         Ok(handle)
     }
 
-    fn notify(&self, shell: &SshShell) -> Result<(), failure::Error> {
+    fn notify(&self, shell: &SshShell) -> Result<(), anyhow::Error> {
         let stop_file_path = format!("/tmp/exp-{}-stop", self.name.replace(" ", "-"));
         shell.run(cmd!("touch {}", stop_file_path))?;
         Ok(())

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -38,7 +38,7 @@ pub enum IntelX86Model {
     KabyLakeConsumer,
 }
 
-pub fn cpu_family_number(ushell: &SshShell) -> Result<usize, failure::Error> {
+pub fn cpu_family_number(ushell: &SshShell) -> Result<usize, anyhow::Error> {
     Ok(ushell
         .run(cmd!(r#"lscpu | grep 'CPU family' | awk '{{print $3}}'"#))?
         .stdout
@@ -46,7 +46,7 @@ pub fn cpu_family_number(ushell: &SshShell) -> Result<usize, failure::Error> {
         .parse::<usize>()?)
 }
 
-pub fn cpu_model_number(ushell: &SshShell) -> Result<usize, failure::Error> {
+pub fn cpu_model_number(ushell: &SshShell) -> Result<usize, anyhow::Error> {
     Ok(ushell
         .run(cmd!(r#"lscpu | grep 'Model:' | awk '{{print $2}}'"#))?
         .stdout
@@ -54,7 +54,7 @@ pub fn cpu_model_number(ushell: &SshShell) -> Result<usize, failure::Error> {
         .parse::<usize>()?)
 }
 
-pub fn cpu_family_model(ushell: &SshShell) -> Result<Processor, failure::Error> {
+pub fn cpu_family_model(ushell: &SshShell) -> Result<Processor, anyhow::Error> {
     use IntelX86Model::*;
 
     let family = cpu_family_number(ushell)?;
@@ -77,12 +77,12 @@ pub fn cpu_family_model(ushell: &SshShell) -> Result<Processor, failure::Error> 
             0x9E | 0x8E => KabyLakeConsumer,
 
             _ => {
-                failure::bail!("Unknown processor: family={} model={}", family, model);
+                anyhow::bail!("Unknown processor: family={} model={}", family, model);
             }
         }),
 
         (family, model) => {
-            failure::bail!("Unknown processor: family={} model={}", family, model);
+            anyhow::bail!("Unknown processor: family={} model={}", family, model);
         }
     })
 }
@@ -93,7 +93,7 @@ pub fn cpu_family_model(ushell: &SshShell) -> Result<Processor, failure::Error> 
 ///
 /// This function checks which it is and returns either `Ok("walk_duration")` or
 /// `Ok("walk_active")`.
-pub fn page_walk_perf_counter_suffix(shell: &SshShell) -> Result<String, failure::Error> {
+pub fn page_walk_perf_counter_suffix(shell: &SshShell) -> Result<String, anyhow::Error> {
     let output = shell
         .run(cmd!(
             "(sudo perf list | grep -o walk_active > /tmp/x && cat /tmp/x | uniq) || echo walk_duration"

--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -51,7 +51,7 @@ pub fn download(
     info: &Download,
     to: &str,
     name: Option<&str>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     // Some websites reject non-browsers, so pretend to be Google Chrome.
     const USER_AGENT: &str = r#"--user-agent="Mozilla/5.0 \
                              (X11; Ubuntu; Linux x86_64; rv:92.0) \
@@ -80,7 +80,7 @@ pub fn download_and_extract(
     info: Download,
     to: &str,
     name: Option<&str>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     // Download, keep the original name.
     download(shell, &info, to, None)?;
 


### PR DESCRIPTION
`failure` is deprecated and now has a minor security advisor (which I'm pretty sure doesn't affect any of our stuff). `anyhow` is a maintained crate by a well-known author that has very similar functionality.