### PR TITLE
Use a custom error type in `libscail`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ authors = ["Mark Mansi <markm@cs.wisc.edu>", "Bijan Tabatabai <btabatabai@wisc.e
 [dependencies]
 spurs = "0.9.0"
 spurs-util = "0.3.0"
-failure = "0.1.5"
-failure_derive = "0.1.5"
 chrono = "0.4.6"
 serde = { version = "1.0.87", features = [ "derive" ] }
 serde_json = "1.0.38"

--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -1,6 +1,8 @@
 //! Utilities for downloading stuff.
 use spurs::{cmd, Execute, SshShell};
 
+use crate::ScailError;
+
 /// Represents a possible artifact that can be downloaded.
 #[derive(Debug, Clone)]
 pub struct Download<'s> {
@@ -51,7 +53,7 @@ pub fn download(
     info: &Download,
     to: &str,
     name: Option<&str>,
-) -> Result<(), failure::Error> {
+) -> Result<(), ScailError> {
     // Some websites reject non-browsers, so pretend to be Google Chrome.
     const USER_AGENT: &str = r#"--user-agent="Mozilla/5.0 \
                              (X11; Ubuntu; Linux x86_64; rv:92.0) \
@@ -80,7 +82,7 @@ pub fn download_and_extract(
     info: Download,
     to: &str,
     name: Option<&str>,
-) -> Result<(), failure::Error> {
+) -> Result<(), ScailError> {
     // Download, keep the original name.
     download(shell, &info, to, None)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use spurs::{cmd, Execute, SshShell};
 
 /// An error type for errors that can be returned by various `libscail` functionality.
+#[derive(Debug)]
 pub enum ScailError {
     /// A local command failed to run because the process began running but terminated with an
     /// error.
@@ -85,6 +86,28 @@ impl From<std::num::ParseIntError> for ScailError {
     fn from(err: std::num::ParseIntError) -> Self {
         Self::InvalidValueError {
             msg: format!("error parsing integer: {err}"),
+        }
+    }
+}
+
+impl std::fmt::Display for ScailError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScailError::CommandError { msg, .. } | ScailError::InvalidValueError { msg } => {
+                write!(f, "{msg}")
+            }
+            ScailError::SpursError(err) => write!(f, "{err}"),
+            ScailError::IoError(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for ScailError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ScailError::CommandError { .. } | ScailError::InvalidValueError { .. } => None,
+            ScailError::SpursError(err) => Some(err.clone()),
+            ScailError::IoError(err) => Some(err.clone()),
         }
     }
 }


### PR DESCRIPTION
This removes the dependency on `failure`, which is no longer maintained and is not compatible with other error handling crates.

This avoids the need for 3rd party crates without creating much extra hassle. It's also the more idiomatic thing to do.