### PR TITLE
Return build paths to kernel build artifacts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,6 +610,8 @@ pub fn get_absolute_path(shell: &SshShell, path: &str) -> Result<String, ScailEr
 /// any.
 ///
 /// `cpupower` indicates whether to build and install `cpupower` (true) or not (false).
+///
+/// Returns the path to the kernel source used to build.
 pub fn build_kernel(
     ushell: &SshShell,
     source: KernelSrc,
@@ -618,7 +620,7 @@ pub fn build_kernel(
     pkg_type: KernelPkgType,
     compiler: Option<&str>,
     cpupower: bool,
-) -> Result<(), ScailError> {
+) -> Result<String, ScailError> {
     // Check out or unpack the source code, returning its absolute path.
     let source_path = match source {
         KernelSrc::Git {
@@ -772,13 +774,13 @@ pub fn build_kernel(
     if cpupower {
         ushell.run(
             cmd!("make -j {} {} && sudo make install", nprocess, compiler)
-                .cwd(&dir!(source_path, "tools/power/cpupower/")),
+                .cwd(&dir!(&source_path, "tools/power/cpupower/")),
         )?;
         // Make sure we reload the ld cache, so that new cpupower library is used.
         ushell.run(cmd!("sudo ldconfig"))?;
     }
 
-    Ok(())
+    Ok(source_path)
 }
 
 /// Something that may be done to a service.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,22 +789,22 @@ pub fn build_kernel(
         KernelPkgType::Deb => {
             let pkg_path = ushell
                 .run(cmd!(
-                    "ls -dArt {source_path} | \
-                grep .*\\.deb |\
-                grep -v headers | \
-                grep -v libc | \
-                grep -v dbg | \
-                tail -n 1"
+                    "ls -dArt {source_path}/* | \
+                        grep '.*\\.deb' |\
+                        grep -v headers | \
+                        grep -v libc | \
+                        grep -v dbg | \
+                        tail -n 1"
                 ))?
                 .stdout
                 .trim()
                 .to_owned();
             let headers_pkg_path = ushell
                 .run(cmd!(
-                    "ls -dArt {source_path} | \
-                grep .*\\.deb | \
-                grep headers | \
-                tail -n 1"
+                    "ls -dArt {source_path}/* | \
+                        grep '.*\\.deb' | \
+                        grep headers | \
+                        tail -n 1"
                 ))?
                 .stdout
                 .trim()
@@ -817,8 +817,8 @@ pub fn build_kernel(
                 .run(
                     cmd!(
                         "ls -Art {user_home}/rpmbuild/RPMS/x86_64/ |\
-                        grep -v headers |\
-                        tail -n 1",
+                            grep -v headers |\
+                            tail -n 1",
                     )
                     .use_bash(),
                 )?
@@ -829,8 +829,8 @@ pub fn build_kernel(
                 .run(
                     cmd!(
                         "ls -Art {user_home}/rpmbuild/RPMS/x86_64/ |\
-                        grep  headers |\
-                        tail -n 1",
+                            grep  headers |\
+                            tail -n 1",
                     )
                     .use_bash(),
                 )?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -789,7 +789,7 @@ pub fn build_kernel(
         KernelPkgType::Deb => {
             let pkg_path = ushell
                 .run(cmd!(
-                    "ls -Art {source_path} | \
+                    "ls -dArt {source_path} | \
                 grep .*\\.deb |\
                 grep -v headers | \
                 grep -v libc | \
@@ -801,7 +801,7 @@ pub fn build_kernel(
                 .to_owned();
             let headers_pkg_path = ushell
                 .run(cmd!(
-                    "ls -Art {source_path} | \
+                    "ls -dArt {source_path} | \
                 grep .*\\.deb | \
                 grep headers | \
                 tail -n 1"


### PR DESCRIPTION
(and also do some minor format string cleanup -- should be most isolated to the first couple of commits).

Currently, every caller of `kernel_build` follows up by figuring out what the paths are. Instead, let's just return them.