### PR TITLE
Better `TasksetCtx`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -160,7 +160,7 @@ pub trait Parametrize: Serialize + Deserialize<'static> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate as runner;
+    use crate as libscail;
 
     #[derive(Debug, Clone, Serialize, Deserialize, Parametrize)]
     struct Test {


### PR DESCRIPTION
cc #5 

More robust support for NUMA topologies.
* Ability to parse the output of `lscpu -p` to get the machine's topology.
* Correct support for skipping hyperthreads.
* Ability to use either round-robin or sequential allocation of cpus across NUMA nodes.
* Uses the "builder" model to make configuration easier. See the tests for examples.
* Hopefully easy-to-extend code (more below).

*Implementation*: the core algorithm for picking the next logical CPU does a topological sort. The giant `compare` closure in `TasksetCtx::advance` defines a total ordering over cpuids in terms of preference. We can then sort the list of cpuids and pick the most preferred one. I implemented some really simple heuristics that should work pretty well if not all cpus are assigned. You may want to tweek the behavior when the counter needs to wrap around again. Hopefully, that is not too complicated.